### PR TITLE
添加获取upload token方法

### DIFF
--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -391,7 +391,7 @@ class QiniuAdapter extends AbstractAdapter
     {
         return $this->uploadManager ?: $this->uploadManager = new UploadManager();
     }
-    
+
     /**
      * Get the upload token.
      *
@@ -405,7 +405,7 @@ class QiniuAdapter extends AbstractAdapter
     {
         return $this->getAuthManager()->uploadToken($this->bucket, $key, $expires, $policy);
     }
-    
+
     /**
      * @param array $stats
      *

--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -391,6 +391,22 @@ class QiniuAdapter extends AbstractAdapter
     {
         return $this->uploadManager ?: $this->uploadManager = new UploadManager();
     }
+    
+    /**
+     * Get the upload token.
+     *
+     * @param null $key
+     *
+     * @param int $expires
+     *
+     * @param null $policy
+     *
+     * @return string
+     */
+    public function getUploadToken($key = null, $expires = 3600, $policy = null)
+    {
+        return $this->getAuthManager()->uploadToken($this->bucket , $key , $expires , $policy);
+    }
 
     /**
      * @param array $stats

--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -397,7 +397,7 @@ class QiniuAdapter extends AbstractAdapter
      *
      * @param null $key
      *
-     * @param int $expires
+     * @param int  $expires
      *
      * @param null $policy
      *
@@ -405,7 +405,7 @@ class QiniuAdapter extends AbstractAdapter
      */
     public function getUploadToken($key = null, $expires = 3600, $policy = null)
     {
-        return $this->getAuthManager()->uploadToken($this->bucket , $key , $expires , $policy);
+        return $this->getAuthManager()->uploadToken($this->bucket, $key, $expires, $policy);
     }
 
     /**

--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -396,9 +396,7 @@ class QiniuAdapter extends AbstractAdapter
      * Get the upload token.
      *
      * @param null $key
-     *
      * @param int  $expires
-     *
      * @param null $policy
      *
      * @return string
@@ -407,7 +405,7 @@ class QiniuAdapter extends AbstractAdapter
     {
         return $this->getAuthManager()->uploadToken($this->bucket, $key, $expires, $policy);
     }
-
+    
     /**
      * @param array $stats
      *


### PR DESCRIPTION
这个方法是用于前端自上传所需要的`token`

laravel-filesystem-qiniu里调用方法是：

> `Storage::disk('qiniu')->getAdapter()->getUploadToken()`

参考：https://developer.qiniu.com/kodo/sdk/1283/javascript