### PR TITLE
fix type hint errors

### DIFF
--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -88,7 +88,7 @@ class QiniuAdapter implements FilesystemAdapter
         return $result;
     }
 
-    public function readStream(string $path): string
+    public function readStream(string $path)
     {
         if (ini_get('allow_url_fopen')) {
             if ($result = fopen($this->privateDownloadUrl($path), 'r')) {
@@ -296,7 +296,7 @@ class QiniuAdapter implements FilesystemAdapter
     {
         return $this->getAuthManager()->uploadToken($this->bucket, $key, $expires, $policy, $strictPolice);
     }
-    
+
     public function verifyCallback(string $contentType = null, string $originAuthorization = null, string $url = null, string $body = null)
     {
         return $this->getAuthManager()->verifyCallback($contentType, $originAuthorization, $url, $body);

--- a/tests/QiniuAdapterTest.php
+++ b/tests/QiniuAdapterTest.php
@@ -308,11 +308,11 @@ class QiniuAdapterTest extends TestCase
         $managers['authManager']->expects()->uploadToken('bucket', 'key', 7200, null, null)->andReturn('token');
         $this->assertSame('token', $adapter->getUploadToken('key', 7200));
 
-        $managers['authManager']->expects()->uploadToken('bucket', 'key', 7200, 'foo', null)->andReturn('token');
-        $this->assertSame('token', $adapter->getUploadToken('key', 7200, 'foo'));
+        $managers['authManager']->expects()->uploadToken('bucket', 'key', 7200, ['foo'], null)->andReturn('token');
+        $this->assertSame('token', $adapter->getUploadToken('key', 7200, ['foo']));
 
-        $managers['authManager']->expects()->uploadToken('bucket', 'key', 7200, 'foo', 'bar')->andReturn('token');
-        $this->assertSame('token', $adapter->getUploadToken('key', 7200, 'foo', 'bar'));
+        $managers['authManager']->expects()->uploadToken('bucket', 'key', 7200, ['foo'], 'bar')->andReturn('token');
+        $this->assertSame('token', $adapter->getUploadToken('key', 7200, ['foo'], 'bar'));
     }
 
     /**


### PR DESCRIPTION
[fopen](https://www.php.net/manual/en/function.fopen.php) 返回值不是 string, 是 resource
不过type hint中并没有resource这个类型，看[官方接口](https://github.com/thephpleague/flysystem/blob/3.x/src/FilesystemAdapter.php#L47)也没有定义返回类型，所以直接去掉
```
#22 {main} {"memory":4070200,"exception":"[object] (TypeError(code: 0): Overtrue\\Flysystem\\Qiniu\\QiniuAdapter::readStream(): Return value must be of type string, resource returned at /Users/thomas/projects/craft-4/vendor/overtrue/flysystem-qiniu/src/QiniuAdapter.php:95)"} 
```

另外修复了测试函数也有两处type hint问题
```
1) Overtrue\Flysystem\Qiniu\Tests\QiniuAdapterTest::testGetUploadToken with data set #0 (Mockery_0_Overtrue_Flysystem_Qiniu_QiniuAdapter Object (...), array(Mockery_1_stdClass Object (...), Mockery_1_stdClass Object (...), Mockery_1_stdClass Object (...), Mockery_1_stdClass Object (...)))
TypeError: Mockery_0_Overtrue_Flysystem_Qiniu_QiniuAdapter::getUploadToken(): Argument #3 ($policy) must be of type ?array, string given, called in /Users/thomas/projects/flysystem-qiniu/tests/QiniuAdapterTest.php on line 312
```