### PR TITLE
完善read方法file_get_content的错误

### DIFF
--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -80,7 +80,12 @@ class QiniuAdapter implements FilesystemAdapter
 
     public function read(string $path): string
     {
-        $result = file_get_contents($this->privateDownloadUrl($path));
+        try {
+            $result = file_get_contents($this->privateDownloadUrl($path));
+        } catch (\Exception $th) {
+            throw UnableToReadFile::fromLocation($path);
+        }
+
         if (false === $result) {
             throw UnableToReadFile::fromLocation($path);
         }


### PR DESCRIPTION
有时候file_get_content会出现错误，会直接抛出异常，从而无法正确的抛出对应的异常UnableToReadFile。因此需要捕获file_get_content的异常或者增加错误抑制符，这里对齐增加异常捕获