### PR TITLE
fix: 修复获取临时 URL 的过期时间逻辑

### DIFF
--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -220,15 +220,21 @@ class QiniuAdapter implements FilesystemAdapter
      */
     public function getTemporaryUrl($path, int|string|\DateTimeInterface $expiration): string
     {
+        $now = time();
+
         if ($expiration instanceof \DateTimeInterface) {
-            $expiration = $expiration->getTimestamp();
+            $expires = $expiration->getTimestamp() - $now;
+        } elseif (is_string($expiration)) {
+            $expires = strtotime($expiration) - $now;
+        } else {
+            $expires = ($expiration > $now) ? ($expiration - $now) : $expiration;
         }
 
-        if (is_string($expiration)) {
-            $expiration = strtotime($expiration);
+        if ($expires <= 0) {
+            $expires = 3600;
         }
 
-        return $this->privateDownloadUrl($path, $expiration);
+        return $this->privateDownloadUrl($path, $expires);
     }
 
     public function privateDownloadUrl(string $path, int $expires = 3600): string


### PR DESCRIPTION
- 统一将 $expiration 转换为剩余秒数，避免最终传递给 privateDownloadUrl 的秒数计算错误
- 添加了对过期时间小于等于 0 的判断和处理