### PR TITLE
use getUploadToken when write.

### DIFF
--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -54,7 +54,7 @@ class QiniuAdapter implements FilesystemAdapter
          * @var Error|null $error
          */
         [, $error] = $this->getUploadManager()->put(
-            $this->getAuthManager()->uploadToken($this->bucket),
+            $this->getUploadToken(),
             $path,
             $contents,
             null,


### PR DESCRIPTION
使用写入时通过getUploadToken方法，这样当开发者需要设置上传策略时，只需要重写getUploadToken方法就够了。否则adapter和auth都要重写。或者重写write方法。都不如直接重写getUploadToken更好。